### PR TITLE
Modified MainForm.cs with TXT export by button

### DIFF
--- a/Application example
+++ b/Application example
@@ -1,0 +1,147 @@
+// This is modified MainForm.cs file, that allows to export processed data to a TXT file
+// Also removed block for exact "unins000.dat" file name, some time sit could be unins001.dat or unins002.dat
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+using ISULR.Model;
+using ISULR.Model.Records;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+using System.Drawing;
+using System.Linq;
+using System.Text;
+
+
+namespace ISULR
+{
+
+    public partial class MainForm : Form
+  {
+    private string filename;
+    private UninstallLog log;
+    private const string TITLE = "InnoSetup Logs Reader";
+
+    public MainForm(string filename)
+    {
+      this.filename = filename;
+      InitializeComponent();
+
+      listView_Resize(listView, EventArgs.Empty);
+      Text = TITLE;
+    }
+
+    private void LoadLog()
+    {
+      using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+        log = new UninstallLog(fs);
+
+      slblRecords.Text = $"Records: {log.Records.Count}";
+      slblAppID.Text = $"ID: {log.AppId}";
+      slblAppName.Text = $"ID: {log.AppName}";
+
+      listView.BeginUpdate();
+      listView.Items.Clear();
+
+      foreach (BaseRecord record in log.Records)
+      {
+        ListViewItem item = new ListViewItem();
+        item.Text = record.Type.ToString();
+        item.SubItems.Add(record.Description);
+        item.Tag = record;
+
+        listView.Items.Add(item);
+      }
+
+      listView.EndUpdate();
+
+      Text = $"{TITLE} - {filename}";
+    }
+
+    private void MainForm_Load(object sender, EventArgs e)
+    {
+      if (filename != null)
+        LoadLog();
+    }
+
+    private void listView_Resize(object sender, EventArgs e)
+    {
+      chDescription.Width = listView.ClientSize.Width - chType.Width;
+    }
+
+    private void MainForm_DragEnter(object sender, DragEventArgs e)
+    {
+      e.Effect = DragDropEffects.None;
+
+      if (!e.Data.GetDataPresent(DataFormats.FileDrop))
+        return;
+
+      string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+      //if (Path.GetFileName(files[0]) != "unins000.dat") // was unins000.dat
+      //          return;
+
+      e.Effect = DragDropEffects.Move;
+    }
+
+    private void MainForm_DragDrop(object sender, DragEventArgs e)
+    {
+      if (!e.Data.GetDataPresent(DataFormats.FileDrop))
+        return;
+
+      string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+    //  if (Path.GetFileName(files[0]) != "unins000.dat") // was unins000.dat
+    //            return;
+
+      filename = files[0];
+
+      LoadLog();
+    }
+
+        
+        private void button1_Click_1(object sender, EventArgs e)
+        {
+
+             // ListView listView1 = new ListView();
+              string splitter = ";";
+              export2File(listView, splitter);
+
+            MessageBox.Show(
+           "Conversion done, please check saved file!",
+           "Information",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information,
+            MessageBoxDefaultButton.Button1,
+            MessageBoxOptions.DefaultDesktopOnly);
+        }
+
+        private void export2File(ListView lv, string splitter)
+        {
+            string filename = "";
+            SaveFileDialog sfd = new SaveFileDialog();
+
+            sfd.Title = "SaveFileDialog Export2File";
+            sfd.Filter = "Text File (.txt) | *.txt";
+
+            if (sfd.ShowDialog() == DialogResult.OK)
+            {
+                filename = sfd.FileName.ToString();
+                if (filename != "")
+                {
+                    using (StreamWriter sw = new StreamWriter(filename))
+                    {
+                        foreach (ListViewItem item in lv.Items)
+                        {
+                            sw.WriteLine("{0}{1}{2}", item.SubItems[0].Text, splitter, item.SubItems[1].Text);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void label1_Click(object sender, EventArgs e)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
This is modified MainForm.cs file, that allows to export processed data to a TXT file using button click
Also removed block for exact "unins000.dat" file name, some time sit could be unins001.dat or unins002.dat